### PR TITLE
Patch host functions so that the name matches with cc3

### DIFF
--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -150,12 +150,12 @@ impl sp_inherents::InherentDataProvider for MockTimestampInherentDataProvider {
 pub type HostFunctions = (
 	frame_benchmarking::benchmarking::HostFunctions,
 	ParachainHostFunctions,
-	moonbeam_primitives_ext::moonbeam_ext::HostFunctions,
+	moonbeam_primitives_ext::creditcoin_3_ext::HostFunctions,
 );
 #[cfg(not(feature = "runtime-benchmarks"))]
 pub type HostFunctions = (
 	ParachainHostFunctions,
-	moonbeam_primitives_ext::moonbeam_ext::HostFunctions,
+	moonbeam_primitives_ext::creditcoin_3_ext::HostFunctions,
 );
 
 /// Block Import Pipeline used.

--- a/primitives/ext/src/lib.rs
+++ b/primitives/ext/src/lib.rs
@@ -31,7 +31,7 @@ use sp_std::vec::Vec;
 use evm_tracing_events::{Event, EvmEvent, GasometerEvent, RuntimeEvent, StepEventFilter};
 
 #[runtime_interface]
-pub trait MoonbeamExt {
+pub trait Creditcoin3Ext {
 	fn raw_step(&mut self, _data: Vec<u8>) {}
 
 	fn raw_gas(&mut self, _data: Vec<u8>) {}

--- a/runtime/evm_tracer/src/lib.rs
+++ b/runtime/evm_tracer/src/lib.rs
@@ -59,7 +59,7 @@ pub mod tracer {
 	impl EvmTracer {
 		pub fn new() -> Self {
 			Self {
-				step_event_filter: moonbeam_primitives_ext::moonbeam_ext::step_event_filter(),
+				step_event_filter: moonbeam_primitives_ext::creditcoin_3_ext::step_event_filter(),
 			}
 		}
 
@@ -84,7 +84,7 @@ pub mod tracer {
 		}
 
 		pub fn emit_new() {
-			moonbeam_primitives_ext::moonbeam_ext::call_list_new();
+			moonbeam_primitives_ext::creditcoin_3_ext::call_list_new();
 		}
 	}
 
@@ -93,7 +93,7 @@ pub mod tracer {
 		fn event(&mut self, event: evm::tracing::Event) {
 			let event: EvmEvent = event.into();
 			let message = event.encode();
-			moonbeam_primitives_ext::moonbeam_ext::evm_event(message);
+			moonbeam_primitives_ext::creditcoin_3_ext::evm_event(message);
 		}
 	}
 
@@ -102,7 +102,7 @@ pub mod tracer {
 		fn event(&mut self, event: evm_gasometer::tracing::Event) {
 			let event: GasometerEvent = event.into();
 			let message = event.encode();
-			moonbeam_primitives_ext::moonbeam_ext::gasometer_event(message);
+			moonbeam_primitives_ext::creditcoin_3_ext::gasometer_event(message);
 		}
 	}
 
@@ -111,7 +111,7 @@ pub mod tracer {
 		fn event(&mut self, event: evm_runtime::tracing::Event) {
 			let event = RuntimeEvent::from_evm_event(event, self.step_event_filter);
 			let message = event.encode();
-			moonbeam_primitives_ext::moonbeam_ext::runtime_event(message);
+			moonbeam_primitives_ext::creditcoin_3_ext::runtime_event(message);
 		}
 	}
 }


### PR DESCRIPTION
### What does it do?
renames moonbeam host function to creditcoin host functions so that the clients don't break when we have a runtime upgrade to the latest polkadot. Additionally gives us the ability to have a single docker image for both normal nodes and the "tracer" nodes (blockscout). After the runtime the normal nodes will be able to continue operating without the client update, while blockscout will have to update their client to be able to use tracing (this is based on current findings, continuing research on that atm)

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
